### PR TITLE
HOTH-1792: Fix node-sass dependency issue

### DIFF
--- a/my_lil_jstor/my_lil_jstor/static/package.json
+++ b/my_lil_jstor/my_lil_jstor/static/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "css-loader": "^0.28.7",
     "extract-text-webpack-plugin": "^3.0.1",
-    "node-sass": "^4.5.3",
+    "node-sass": "4.6.1",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.19.0",
     "url-loader": "^0.6.1",


### PR DESCRIPTION
NPM was throwing some alerts because `node-sass` was using some dependancies with known 
 security vulnerabilities. The devs of `node-sass` are aware of this issue and is currently being tracked under this PR: https://github.com/sass/node-sass/issues/2355

Bad news is that this is not actually fixed yet in the latest version, due to some breaking changes with their other dependancies. One of the solutions as a temporary fix was to downgrade to `4.7.0`. Not really sure where they got this version, because I do not see it published in npm. However, I tried downgrading to `4.6.1` seemed to do the trick (no vulnerability alerts). After doing this, I was able to install dependancies, build static assets with webpack, and load up the lil-jstor page just fine. We might want to revisit this when `node-sass` v5 is released.